### PR TITLE
Compilation avec le eigen de sofa

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(CoMISo STATIC
 
 target_include_directories(CoMISo PUBLIC
   "${CMAKE_CURRENT_SOURCE_DIR}/.."
-  "${CMAKE_CURRENT_SOURCE_DIR}/../eigen"
+  "${EIGEN_ROOT}"
   "${CMAKE_CURRENT_SOURCE_DIR}/ext/gmm-4.2/include")
 target_compile_definitions(CoMISo PUBLIC -DINCLUDE_TEMPLATES)
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # CoMISo
 This is a mirror of the latest stable version of CoMISo
+
+WARNING : CoMISo use GPL license, don't use for commercial purpose !


### PR DESCRIPTION
Ajout de la variable "EIGEN_ROOT" dans le CMakeList.

Cette variable nous permet de spécifier le eigen qui va être utilisé par CoMISo.

La variable "EIGEN_ROOT" va être transmit par le CMakeList de igl